### PR TITLE
bugfix where onEndReached called twice on Render causing multiple api…

### DIFF
--- a/components/UI/RedditDataScroller.tsx
+++ b/components/UI/RedditDataScroller.tsx
@@ -89,7 +89,9 @@ function RedditDataScroller<T extends RedditDataObject>(
       scrollEventThrottle={100}
       onEndReachedThreshold={2}
       onEndReached={() => {
-        loadMoreData();
+        if (props.data.length > 0) {
+          loadMoreData();
+        }
       }}
       data={props.data}
       keyExtractor={(item) => `${item.type}-${item.id}`}


### PR DESCRIPTION
When opening different subreddits, the initial call to `getPosts()` with an empty `after` param is triggered twice causing an initial duplicate network request due to `onEndReached`.

This bug is pretty common ([example](https://stackoverflow.com/questions/47910127/flatlist-calls-onendreached-when-its-rendered))