### PR TITLE
Correctly apply custom API endpoint in the app

### DIFF
--- a/constants/HydraServer.ts
+++ b/constants/HydraServer.ts
@@ -4,8 +4,9 @@ export const USE_CUSTOM_HYDRA_SERVER_KEY = "useHydraServer";
 export const CUSTOM_HYDRA_SERVER_URL_KEY = "customHydraServerUrl";
 export const DEFAULT_HYDRA_SERVER_URL = "https://api.hydraapp.io";
 export const HYDRA_SERVER_URL = __DEV__
-  ? process.env.EXPO_PUBLIC_HYDRA_SERVER
-  : "https://api.hydraapp.io";
+  ? (process.env.EXPO_PUBLIC_HYDRA_SERVER ?? DEFAULT_HYDRA_SERVER_URL)
+  : (KeyStore.getString(CUSTOM_HYDRA_SERVER_URL_KEY) ??
+    DEFAULT_HYDRA_SERVER_URL);
 
 export const USING_CUSTOM_HYDRA_SERVER =
   (KeyStore.getBoolean(USE_CUSTOM_HYDRA_SERVER_KEY) ?? false) &&


### PR DESCRIPTION
I've been using Hydra for a while now and I'm really loving it. Following the release of 2.7.1 I have setup my self-hosted API, and I can confirm the API works as Hydra reported successful (GET from `{API_URL}/api/status`).

However I still find myself not being able to use the AI feature (always getting the "Customer is not subscribed" message) even though I have correctly setup Groq apikey. Checking the log, I've also noticed that Hydra is still sending request to `api.hydraapp.io` (The only request that is actually being sent to my own API is the one described above.) And I've identified the problem being that the user-defined API isn't really applied within https://github.com/dmilin1/hydra/blob/f1e1ced06a46cb38faa8176e217b5b8138796777/constants/HydraServer.ts#L6-L8

This PR fixes the problem (tested on a ios device) described above while making sure that overriding default API is still possible by setting `EXPO_PUBLIC_HYDRA_SERVER` in debug builds.