### PR TITLE
Handle private and banned subreddits

### DIFF
--- a/api/Posts.ts
+++ b/api/Posts.ts
@@ -251,6 +251,18 @@ export async function getPosts(
   );
   return posts;
 }
+export async function fetchPostsAccessStatus(
+  url: string,
+): Promise<{ reason: string | null; success: boolean; name: string | null }> {
+  const redditURL = new RedditURL(url);
+  const subreddit = redditURL.getSubreddit();
+  redditURL.jsonify();
+  const response = await api(redditURL.toString());
+  if (response.reason === "banned" || response.reason === "private") {
+    return {success: false, reason: response.reason, name: subreddit };
+  }
+  return {success: true, reason: null, name: subreddit };
+}
 
 function handleGatedSubreddit(
   warning: string,

--- a/pages/PostsPage.tsx
+++ b/pages/PostsPage.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useRef, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import React, { useContext, useRef, useState, useEffect } from "react";
+import { StyleSheet, View, Text } from "react-native";
+import { getPosts, Post, fetchPostsAccessStatus } from "../api/Posts";
 
-import { getPosts, Post } from "../api/Posts";
 import { StackPageProps } from "../app/stack";
 import PostComponent from "../components/RedditDataRepresentations/Post/PostComponent";
 import RedditDataScroller from "../components/UI/RedditDataScroller";
@@ -28,6 +28,16 @@ export default function PostsPage({
   const [rerenderCount, rerender] = useState(0);
 
   const shouldFilterSeen = getHideSeenURLStatus(url);
+
+  const [postsAccessStatus, setpostsAccessStatus] = useState<{
+    reason: string | null;
+    success: boolean;
+    name: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    fetchPostsAccessStatus(url).then(setpostsAccessStatus);
+  }, [url]);
 
   const {
     data: posts,
@@ -59,6 +69,33 @@ export default function PostsPage({
       rerender((prev) => prev + 1);
     }
   };
+
+
+  if (postsAccessStatus && !postsAccessStatus.success) {
+    const text = (postsAccessStatus.reason === "private")
+      ? (`🔑 r/${postsAccessStatus.name} has been set to private by its subreddit moderators`)
+      : (`🚫 r/${postsAccessStatus.name} has been banned by Reddit Administrators for breaking Reddit rules`);
+    return (
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Text
+          style={{
+            fontSize: 16,
+            color: theme.text,
+            textAlign: "center",
+            maxWidth: 320,
+          }}
+        >
+          {text}
+        </Text>
+      </View>
+    );
+  }
 
   return (
     <View


### PR DESCRIPTION
Thanks for creating this app! I started using it a few days ago and stumbled upon a private subreddit that I saw was not handled. Let me know if I missed something or if you want it to be moved to handleGatedSubreddit, as I saw that you had that method. I’m fairly new to this stack.  I tried to mimic how Apollo was handling it.

This is how it looks when I handle them now instead of spinning in a loop.

When a sub is private: (If you have access to the private sub, it will load as normal)
![image](https://github.com/user-attachments/assets/cdadbf22-b20a-4e75-b20d-2e62107d809c)

when a sub is banned:
![image](https://github.com/user-attachments/assets/3dd70c46-6aa2-4a94-a2c2-cba1cb1b09f6)





