### PR TITLE
Add live text

### DIFF
--- a/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/ImageView/components/ImageItem/ImageItem.ios.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/ImageView/components/ImageItem/ImageItem.ios.tsx
@@ -1,5 +1,5 @@
 import { Image } from "expo-image";
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useContext, useRef, useState } from "react";
 import {
   Animated,
   Dimensions,
@@ -15,6 +15,7 @@ import { ImageSource } from "../../@types";
 import useDoubleTapToZoom from "../../hooks/useDoubleTapToZoom";
 import useImageDimensions from "../../hooks/useImageDimensions";
 import { getImageStyles, getImageTransform } from "../../utils";
+import { PostSettingsContext } from "../../../../../../../../contexts/SettingsContexts/PostSettingsContext";
 
 const SWIPE_CLOSE_OFFSET = 50;
 const SWIPE_CLOSE_VELOCITY = 1.55;
@@ -46,6 +47,7 @@ const ImageItem = ({
   const [scaled, setScaled] = useState(false);
   const imageDimensions = useImageDimensions(imageSrc);
   const handleDoubleTap = useDoubleTapToZoom(scrollViewRef, scaled, SCREEN);
+  const { liveTextInteraction } = useContext(PostSettingsContext);
 
   const [translate, scale] = getImageTransform(imageDimensions, SCREEN);
   const scrollValueY = new Animated.Value(0);
@@ -161,13 +163,14 @@ const ImageItem = ({
         <TouchableWithoutFeedback
           onPress={doubleTapToZoomEnabled ? handleDoubleTap : undefined}
           onLongPress={onLongPressHandler}
-          delayLongPress={delayLongPress}
+          delayLongPress={liveTextInteraction ? 1500 : delayLongPress}
         >
           <Animated.View style={imagesStyles}>
             <Image
               source={imageSrc}
               style={{ width: "100%", height: "100%" }}
               onLoad={() => setLoaded(true)}
+              enableLiveTextInteraction={liveTextInteraction}
             />
           </Animated.View>
         </TouchableWithoutFeedback>

--- a/contexts/SettingsContexts/PostSettingsContext.tsx
+++ b/contexts/SettingsContexts/PostSettingsContext.tsx
@@ -12,6 +12,7 @@ const initialValues = {
   blurNSFW: true,
   showPostSummary: true,
   autoPlayVideos: true,
+  liveTextInteraction: false,
 };
 
 const initialPostSettingsContext = {
@@ -26,6 +27,7 @@ const initialPostSettingsContext = {
   toggleBlurNSFW: (_newValue?: boolean) => {},
   toggleShowPostSummary: (_newValue?: boolean) => {},
   toggleAutoPlayVideos: (_newValue?: boolean) => {},
+  toggleLiveTextInteraction: (_newValue?: boolean) => {},
 };
 
 export const PostSettingsContext = createContext(initialPostSettingsContext);
@@ -75,6 +77,11 @@ export function PostSettingsProvider({ children }: React.PropsWithChildren) {
     useMMKVBoolean("autoPlayVideos");
   const autoPlayVideos = storedAutoPlayVideos ?? initialValues.autoPlayVideos;
 
+  const [storedliveTextInteraction, setliveTextInteraction] =
+    useMMKVBoolean("liveTextInteraction");
+  const liveTextInteraction =
+    storedliveTextInteraction ?? initialValues.liveTextInteraction;
+
   return (
     <PostSettingsContext.Provider
       value={{
@@ -116,6 +123,11 @@ export function PostSettingsProvider({ children }: React.PropsWithChildren) {
         autoPlayVideos: autoPlayVideos ?? initialValues.autoPlayVideos,
         toggleAutoPlayVideos: (newValue = !autoPlayVideos) =>
           setAutoPlayVideos(newValue),
+
+        liveTextInteraction:
+          liveTextInteraction ?? initialValues.liveTextInteraction,
+        toggleLiveTextInteraction: (newValue = !liveTextInteraction) =>
+          setliveTextInteraction(newValue),
       }}
     >
       {children}

--- a/pages/SettingsPage/Appearance.tsx
+++ b/pages/SettingsPage/Appearance.tsx
@@ -45,6 +45,8 @@ export default function Appearance() {
     toggleShowPostSummary,
     autoPlayVideos,
     toggleAutoPlayVideos,
+    liveTextInteraction,
+    toggleLiveTextInteraction,
   } = useContext(PostSettingsContext);
 
   const {
@@ -296,6 +298,24 @@ export default function Appearance() {
             ),
             text: "Auto play videos",
             onPress: () => toggleAutoPlayVideos(),
+          },
+          {
+            key: "liveTextInteraction",
+            icon: (<MaterialIcons name="document-scanner" size={24} color={theme.text}
+            />
+            ),
+            rightIcon: (
+              <Switch
+                trackColor={{
+                  false: theme.iconSecondary,
+                  true: theme.iconPrimary,
+                }}
+                value={liveTextInteraction}
+                onValueChange={() => toggleLiveTextInteraction()}
+              />
+            ),
+            text: "Live text",
+            onPress: () => toggleLiveTextInteraction(),
           },
         ]}
       />


### PR DESCRIPTION
Just a small addition that adds live text as seen in pictures and that is an optional toggle in settings 

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-27 at 22 31 37" src="https://github.com/user-attachments/assets/0566a2d4-4f08-4a7c-bcea-752085b580ee" />


<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-27 at 22 33 46" src="https://github.com/user-attachments/assets/edc9e573-2cd3-4eb2-a3d3-d960f6e430ed" />


<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-27 at 22 36 13" src="https://github.com/user-attachments/assets/b7874ae0-b58b-4fe4-8f6c-05d24f71f864" />
