### PR TITLE
Feat: Translation

### DIFF
--- a/api/AI.ts
+++ b/api/AI.ts
@@ -88,3 +88,41 @@ export async function askQuestion(
   });
   return await response.json();
 }
+
+export async function translatePost(
+  customerId: string,
+  postTitle: string,
+  postText: string,
+  sourceLanguage: string,
+  targetLanguage: string,
+): Promise<string> {
+  const response = await fetch(`${HYDRA_SERVER_URL}/api/ai/translatePost`, {
+    method: "POST",
+    body: JSON.stringify({
+      customerId,
+      postTitle,
+      postText: postText.slice(0, 15_000),
+      sourceLanguage,
+      targetLanguage,
+    }),
+  });
+  return await response.text();
+}
+
+export async function translateComment(
+  customerId: string,
+  comment: string,
+  sourceLanguage: string,
+  targetLanguage: string,
+): Promise<string> {
+  const response = await fetch(`${HYDRA_SERVER_URL}/api/ai/translateComment`, {
+    method: "POST",
+    body: JSON.stringify({
+      customerId,
+      comment: comment.slice(0, 3_000),
+      sourceLanguage,
+      targetLanguage,
+    }),
+  });
+  return await response.text();
+}

--- a/api/AI.ts
+++ b/api/AI.ts
@@ -89,39 +89,21 @@ export async function askQuestion(
   return await response.json();
 }
 
-export async function translatePost(
+export async function translate(
   customerId: string,
-  postTitle: string,
-  postText: string,
+  type: "post" | "comment",
   sourceLanguage: string,
   targetLanguage: string,
+  content: { postTitle?: string; postText?: string; comment?: string },
 ): Promise<string> {
-  const response = await fetch(`${HYDRA_SERVER_URL}/api/ai/translatePost`, {
+  const response = await fetch(`${HYDRA_SERVER_URL}/api/ai/translate`, {
     method: "POST",
     body: JSON.stringify({
       customerId,
-      postTitle,
-      postText: postText.slice(0, 15_000),
+      type,
       sourceLanguage,
       targetLanguage,
-    }),
-  });
-  return await response.text();
-}
-
-export async function translateComment(
-  customerId: string,
-  comment: string,
-  sourceLanguage: string,
-  targetLanguage: string,
-): Promise<string> {
-  const response = await fetch(`${HYDRA_SERVER_URL}/api/ai/translateComment`, {
-    method: "POST",
-    body: JSON.stringify({
-      customerId,
-      comment: comment.slice(0, 3_000),
-      sourceLanguage,
-      targetLanguage,
+      ...content,
     }),
   });
   return await response.text();

--- a/components/Modals/TranslationModal.tsx
+++ b/components/Modals/TranslationModal.tsx
@@ -1,0 +1,114 @@
+import React, { useContext } from "react";
+import { StyleSheet, View, Text, ScrollView, useWindowDimensions, TouchableOpacity } from "react-native";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+
+import { ModalContext } from "../../contexts/ModalContext";
+import { ThemeContext } from "../../contexts/SettingsContexts/ThemeContext";
+
+type TranslationModalProps = {
+  originalText: string;
+  translatedText: string;
+};
+
+export default function TranslationModal({ originalText, translatedText }: TranslationModalProps) {
+  const { theme } = useContext(ThemeContext);
+  const { setModal } = useContext(ModalContext);
+
+  const { width, height } = useWindowDimensions();
+
+  return (
+    <>
+      <View
+        style={[
+          styles.translationContainer,
+          {
+            backgroundColor: theme.tint,
+            borderColor: theme.divider,
+            bottom: -height,
+            left: -3,
+            width: width + 6,
+            height: height * 0.65,
+          },
+        ]}
+      >
+        <View style={styles.header}>
+          <Text style={[styles.title, { color: theme.text }]}>Translation</Text>
+          <TouchableOpacity
+            style={styles.closeButton}
+            onPress={() => setModal(null)}
+          >
+            <MaterialCommunityIcons name="close" size={24} color={theme.text} />
+          </TouchableOpacity>
+        </View>
+        
+        <View style={styles.section}>
+          <Text style={[styles.sectionTitle, { color: theme.subtleText }]}>Original</Text>
+          <ScrollView style={styles.textScroll}>
+            <Text style={[styles.text, { color: theme.text }]}>{originalText}</Text>
+          </ScrollView>
+        </View>
+        
+        <View style={styles.section}>
+          <Text style={[styles.sectionTitle, { color: theme.subtleText }]}>Translated</Text>
+          <ScrollView style={styles.textScroll}>
+            <Text style={[styles.text, { color: theme.text }]}>{translatedText}</Text>
+          </ScrollView>
+        </View>
+      </View>
+      <View
+        style={[styles.background, { height }]}
+        onTouchStart={() => {
+          setModal(null);
+        }}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  translationContainer: {
+    position: "absolute",
+    zIndex: 1,
+    borderRadius: 30,
+    paddingVertical: 20,
+    paddingHorizontal: 20,
+    borderWidth: 3,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "bold",
+  },
+  closeButton: {
+    padding: 5,
+  },
+  section: {
+    flex: 1,
+    marginBottom: 15,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: 8,
+  },
+  textScroll: {
+    flex: 1,
+  },
+  text: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  background: {
+    position: "absolute",
+    width: "100%",
+    top: 0,
+    left: 0,
+    backgroundColor: "black",
+    opacity: 0.7,
+  },
+});

--- a/components/Navbar/SortAndContext.tsx
+++ b/components/Navbar/SortAndContext.tsx
@@ -33,7 +33,7 @@ import { ThemeContext } from "../../contexts/SettingsContexts/ThemeContext";
 import { TranslationSettingsContext } from "../../contexts/SettingsContexts/TranslationSettingsContext";
 import { SubscriptionsContext } from "../../contexts/SubscriptionsContext";
 import { SubredditContext } from "../../contexts/SubredditContext";
-import { translatePost } from "../../api/AI";
+import { translate } from "../../api/AI";
 import TranslationModal from "../Modals/TranslationModal";
 import KeyStore from "../../utils/KeyStore";
 import RedditURL, { PageType } from "../../utils/RedditURL";
@@ -380,12 +380,12 @@ export default function SortAndContext({
               openGallery(currentPath);
             } else if (result === "Translate Text" && isPro && customerId && pageData?.type === "postDetail") {
               try {
-                const translation = await translatePost(
+                const translation = await translate(
                   customerId,
-                  pageData.title,
-                  pageData.text || "",
+                  "post",
                   sourceLanguage,
                   targetLanguage,
+                  { postTitle: pageData.title, postText: pageData.text || "" },
                 );
                 setModal(
                   <TranslationModal 

--- a/components/RedditDataRepresentations/Post/PostDetailsComponent.tsx
+++ b/components/RedditDataRepresentations/Post/PostDetailsComponent.tsx
@@ -25,7 +25,7 @@ import {
 import PostMedia from "./PostParts/PostMedia";
 import SubredditIcon from "./PostParts/SubredditIcon";
 import { summarizePostDetails, summarizePostComments } from "../../../api/AI";
-import { translatePost } from "../../../api/AI";
+import { translate } from "../../../api/AI";
 import TranslationModal from "../../Modals/TranslationModal";
 import { PostDetail, vote } from "../../../api/PostDetail";
 import { VoteOption } from "../../../api/Posts";
@@ -88,12 +88,12 @@ export default function PostDetailsComponent({
     if (!isPro || !customerId) return;
     
     try {
-      const translation = await translatePost(
+      const translation = await translate(
         customerId,
-        postDetail.title,
-        postDetail.text || "",
+        "post",
         sourceLanguage,
         targetLanguage,
+        { postTitle: postDetail.title, postText: postDetail.text || "" },
       );
       setModal(
         <TranslationModal 

--- a/components/RedditDataRepresentations/Post/PostParts/Comments.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/Comments.tsx
@@ -37,7 +37,7 @@ import {
 } from "../../../../api/PostDetail";
 import { VoteOption } from "../../../../api/Posts";
 import { saveItem } from "../../../../api/Save";
-import { translateComment } from "../../../../api/AI";
+import { translate } from "../../../../api/AI";
 import { AccountContext } from "../../../../contexts/AccountContext";
 import { ModalContext } from "../../../../contexts/ModalContext";
 import { CommentSettingsContext } from "../../../../contexts/SettingsContexts/CommentSettingsContext";
@@ -200,11 +200,12 @@ export function CommentComponent({
     if (!isPro || !customerId) return;
     
     try {
-      const translation = await translateComment(
+      const translation = await translate(
         customerId,
-        comment.text,
+        "comment",
         sourceLanguage,
         targetLanguage,
+        { comment: comment.text },
       );
       setModal(
         <TranslationModal 

--- a/contexts/SettingsContexts/TranslationSettingsContext.tsx
+++ b/contexts/SettingsContexts/TranslationSettingsContext.tsx
@@ -1,0 +1,60 @@
+import { createContext } from "react";
+import { useMMKVString } from "react-native-mmkv";
+
+export const SUPPORTED_LANGUAGES = [
+  { code: "auto", name: "Auto Detect" },
+  { code: "en", name: "English" },
+  { code: "zh-Hant", name: "Chinese Traditional" },
+  { code: "zh-Hans", name: "Chinese Simplified" },
+  { code: "es", name: "Spanish" },
+  { code: "fr", name: "French" },
+  { code: "de", name: "German" },
+  { code: "pt", name: "Portuguese" },
+  { code: "ja", name: "Japanese" },
+  { code: "ko", name: "Korean" },
+  { code: "ru", name: "Russian" },
+] as const;
+
+type LanguageCode = typeof SUPPORTED_LANGUAGES[number]["code"];
+
+const initialValues = {
+  sourceLanguage: "auto" as LanguageCode,
+  targetLanguage: "en" as LanguageCode,
+};
+
+const initialTranslationSettingsContext = {
+  ...initialValues,
+  setSourceLanguage: (_language: LanguageCode) => {},
+  setTargetLanguage: (_language: LanguageCode) => {},
+};
+
+export const TranslationSettingsContext = createContext(
+  initialTranslationSettingsContext,
+);
+
+export function TranslationSettingsProvider({
+  children,
+}: React.PropsWithChildren) {
+  const [storedSourceLanguage, setSourceLanguage] = useMMKVString(
+    "translationSourceLanguage",
+  );
+  const sourceLanguage = (storedSourceLanguage ?? initialValues.sourceLanguage) as LanguageCode;
+
+  const [storedTargetLanguage, setTargetLanguage] = useMMKVString(
+    "translationTargetLanguage",
+  );
+  const targetLanguage = (storedTargetLanguage ?? initialValues.targetLanguage) as LanguageCode;
+
+  return (
+    <TranslationSettingsContext.Provider
+      value={{
+        sourceLanguage,
+        targetLanguage,
+        setSourceLanguage,
+        setTargetLanguage,
+      }}
+    >
+      {children}
+    </TranslationSettingsContext.Provider>
+  );
+}

--- a/contexts/SettingsContexts/index.tsx
+++ b/contexts/SettingsContexts/index.tsx
@@ -6,6 +6,7 @@ import { NotificationsProvider } from "./NotificationsContext";
 import { PostSettingsProvider } from "./PostSettingsContext";
 import { TabSettingsProvider } from "./TabSettingsContext";
 import { ThemeProvider } from "./ThemeContext";
+import { TranslationSettingsProvider } from "./TranslationSettingsContext";
 
 export function SettingsProvider({ children }: React.PropsWithChildren) {
   return (
@@ -16,7 +17,9 @@ export function SettingsProvider({ children }: React.PropsWithChildren) {
             <PostSettingsProvider>
               <FiltersProvider>
                 <CommentSettingsProvider>
-                  <TabSettingsProvider>{children}</TabSettingsProvider>
+                  <TranslationSettingsProvider>
+                    <TabSettingsProvider>{children}</TabSettingsProvider>
+                  </TranslationSettingsProvider>
                 </CommentSettingsProvider>
               </FiltersProvider>
             </PostSettingsProvider>

--- a/pages/PostDetails.tsx
+++ b/pages/PostDetails.tsx
@@ -40,7 +40,6 @@ import { modifyStat, Stat } from "../db/functions/Stats";
 import ScrollToNextButtonProvider from "../contexts/ScrollToNextButtonProvider";
 import { ScrollToNextButtonContext } from "../contexts/ScrollToNextButtonContext";
 import { summarizePostDetails, summarizePostComments } from "../api/AI";
-import { translatePost } from "../api/AI";
 import TranslationModal from "../components/Modals/TranslationModal";
 
 export type LoadMoreCommentsFunc = (

--- a/pages/SettingsPage/General/GeneralRoot.tsx
+++ b/pages/SettingsPage/General/GeneralRoot.tsx
@@ -8,66 +8,79 @@ import React, { useContext } from "react";
 
 import List from "../../../components/UI/List";
 import { ThemeContext } from "../../../contexts/SettingsContexts/ThemeContext";
+import { SubscriptionsContext } from "../../../contexts/SubscriptionsContext";
 import { useURLNavigation } from "../../../utils/navigation";
 
 export default function GeneralRoot() {
   const { theme } = useContext(ThemeContext);
+  const { isPro } = useContext(SubscriptionsContext);
   const { pushURL } = useURLNavigation();
+
+  const generalItems = [
+    {
+      key: "gestures",
+      icon: <FontAwesome name="hand-o-up" size={24} color={theme.text} />,
+      text: "Gestures",
+      onPress: () => pushURL("hydra://settings/general/gestures"),
+    },
+    {
+      key: "sorting",
+      icon: <FontAwesome name="sort" size={24} color={theme.text} />,
+      text: "Post & Comment Sorting",
+      onPress: () => pushURL("hydra://settings/general/sorting"),
+    },
+    {
+      key: "filters",
+      icon: <AntDesign name="filter" size={24} color={theme.text} />,
+      text: "Filters",
+      onPress: () => pushURL("hydra://settings/general/filters"),
+    },
+    {
+      key: "openInHydra",
+      icon: <Feather name="external-link" size={24} color={theme.text} />,
+      text: "Open in Hydra",
+      onPress: () => pushURL("hydra://settings/general/openInHydra"),
+    },
+    {
+      key: "startup",
+      icon: (
+        <MaterialCommunityIcons
+          name="restart"
+          size={24}
+          color={theme.text}
+        />
+      ),
+      text: "App Startup",
+      onPress: () => pushURL("hydra://settings/general/startup"),
+    },
+    {
+      key: "legal",
+      icon: <Feather name="file-text" size={24} color={theme.text} />,
+      text: "Legal",
+      onPress: () => pushURL("hydra://settings/general/legal"),
+    },
+    {
+      key: "externalLinks",
+      icon: <Feather name="link" size={22} color={theme.text} />,
+      text: "External Links",
+      onPress: () => pushURL("hydra://settings/general/externalLinks"),
+    },
+  ];
+
+  if (isPro) {
+    generalItems.splice(5, 0, {
+      key: "translations",
+      icon: <MaterialCommunityIcons name="translate" size={24} color={theme.text} />,
+      text: "Translations",
+      onPress: () => pushURL("hydra://settings/general/translations"),
+    });
+  }
 
   return (
     <>
       <List
         title="General"
-        items={[
-          {
-            key: "gestures",
-            icon: <FontAwesome name="hand-o-up" size={24} color={theme.text} />,
-            text: "Gestures",
-            onPress: () => pushURL("hydra://settings/general/gestures"),
-          },
-          {
-            key: "sorting",
-            icon: <FontAwesome name="sort" size={24} color={theme.text} />,
-            text: "Post & Comment Sorting",
-            onPress: () => pushURL("hydra://settings/general/sorting"),
-          },
-          {
-            key: "filters",
-            icon: <AntDesign name="filter" size={24} color={theme.text} />,
-            text: "Filters",
-            onPress: () => pushURL("hydra://settings/general/filters"),
-          },
-          {
-            key: "openInHydra",
-            icon: <Feather name="external-link" size={24} color={theme.text} />,
-            text: "Open in Hydra",
-            onPress: () => pushURL("hydra://settings/general/openInHydra"),
-          },
-          {
-            key: "startup",
-            icon: (
-              <MaterialCommunityIcons
-                name="restart"
-                size={24}
-                color={theme.text}
-              />
-            ),
-            text: "App Startup",
-            onPress: () => pushURL("hydra://settings/general/startup"),
-          },
-          {
-            key: "legal",
-            icon: <Feather name="file-text" size={24} color={theme.text} />,
-            text: "Legal",
-            onPress: () => pushURL("hydra://settings/general/legal"),
-          },
-          {
-            key: "externalLinks",
-            icon: <Feather name="link" size={22} color={theme.text} />,
-            text: "External Links",
-            onPress: () => pushURL("hydra://settings/general/externalLinks"),
-          },
-        ]}
+        items={generalItems}
       />
     </>
   );

--- a/pages/SettingsPage/General/Translations.tsx
+++ b/pages/SettingsPage/General/Translations.tsx
@@ -1,0 +1,107 @@
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import React, { useContext } from "react";
+import { View, StyleSheet } from "react-native";
+
+import List from "../../../components/UI/List";
+import { ThemeContext } from "../../../contexts/SettingsContexts/ThemeContext";
+import { TranslationSettingsContext, SUPPORTED_LANGUAGES } from "../../../contexts/SettingsContexts/TranslationSettingsContext";
+import { SubscriptionsContext } from "../../../contexts/SubscriptionsContext";
+import { useSettingsPicker } from "../../../utils/useSettingsPicker";
+
+export default function Translations() {
+  const { theme } = useContext(ThemeContext);
+  const { sourceLanguage, targetLanguage, setSourceLanguage, setTargetLanguage } = useContext(TranslationSettingsContext);
+  const { isPro } = useContext(SubscriptionsContext);
+
+  const sourceLanguageOptions = SUPPORTED_LANGUAGES.map(lang => ({
+    label: lang.name,
+    value: lang.code,
+  }));
+
+  const targetLanguageOptions = SUPPORTED_LANGUAGES.filter(lang => lang.code !== "auto").map(lang => ({
+    label: lang.name,
+    value: lang.code,
+  }));
+
+  const {
+    openPicker: openSourceLanguagePicker,
+    rightIcon: rightIconSourceLanguage,
+  } = useSettingsPicker({
+    items: sourceLanguageOptions,
+    value: sourceLanguage,
+    onChange: (newValue) => {
+      if (isPro) {
+        setSourceLanguage(newValue);
+      }
+    },
+  });
+
+  const {
+    openPicker: openTargetLanguagePicker,
+    rightIcon: rightIconTargetLanguage,
+  } = useSettingsPicker({
+    items: targetLanguageOptions,
+    value: targetLanguage,
+    onChange: (newValue) => {
+      if (isPro) {
+        setTargetLanguage(newValue);
+      }
+    },
+  });
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <List
+        title="Languages"
+        items={[
+          {
+            key: "sourceLanguage",
+            icon: <MaterialCommunityIcons name="translate" size={24} color={theme.text} />,
+            text: "Source Language",
+            rightIcon: rightIconSourceLanguage,
+            onPress: () => {
+              if (isPro) {
+                openSourceLanguagePicker();
+              }
+            },
+          },
+          {
+            key: "targetLanguage",
+            icon: <MaterialCommunityIcons name="translate" size={24} color={theme.text} />,
+            text: "Target Language",
+            rightIcon: rightIconTargetLanguage,
+            onPress: () => {
+              if (isPro) {
+                openTargetLanguagePicker();
+              }
+            },
+          },
+        ]}
+      />
+      {!isPro && (
+        <View style={styles.proNotice}>
+          <MaterialCommunityIcons name="crown" size={20} color={theme.pro} />
+          <List
+            items={[
+              {
+                key: "pro",
+                text: "Upgrade to Pro to use translation features",
+                icon: <MaterialCommunityIcons name="crown" size={24} color={theme.pro} />,
+              },
+            ]}
+          />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  proNotice: {
+    marginTop: 20,
+    paddingHorizontal: 15,
+  },
+});

--- a/pages/SettingsPage/index.tsx
+++ b/pages/SettingsPage/index.tsx
@@ -24,6 +24,7 @@ import Gestures from "./General/Gestures";
 import Stats from "./Stats";
 import AppIcon from "./General/AppIcon/AppIcon";
 import AppIconDetails from "./General/AppIcon/AppIconDetails";
+import Translations from "./General/Translations";
 
 /**
  * Important to load this lazily since the guide loads the large documentation
@@ -68,6 +69,7 @@ export default function SettingsPage({
         {relativePath === "settings/general/startup" && <Startup />}
         {relativePath === "settings/general/legal" && <Legal />}
         {relativePath === "settings/general/externalLinks" && <ExternalLinks />}
+        {relativePath === "settings/general/translations" && <Translations />}
 
         {relativePath === "settings/theme" && <Theme />}
         {relativePath === "settings/themeMaker" && <ThemeMaker />}


### PR DESCRIPTION
Pairs with [PR 9 on hydra-server](https://github.com/dmilin1/hydra-server/pull/9); this adds translation capability to Hydra. It performs the same LLM usage accounting, so if I am not misunderstanding it, it should not affect your operational cost/margin on Pro subscription. As noted in the other PR, I've tested against `groq` on my custom server and it seems to work okay with translations to the major languages.  I am not usually an expo dev, so please do feel free to reject and reimplement as you see fit.

Thank you for building this!