### PR TITLE
Fix image viewer freeze when opening images from feed

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "WebFetch(domain:github.com)",
-      "WebFetch(domain:raw.githubusercontent.com)"
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:www.npmjs.com)"
     ]
   }
 }

--- a/api/User.ts
+++ b/api/User.ts
@@ -24,6 +24,10 @@ export type User = {
 
 export type UserContent = Post | Comment | PostDetail | CommentReply;
 
+type GetUserOptions = {
+  allowSuspended?: boolean;
+};
+
 type GetUserContentOptions = {
   limit?: string;
   after?: string;
@@ -64,8 +68,11 @@ export function formatUserData(child: any): User {
   };
 }
 
-function handleBadUserResponse(response: any) {
-  if (response.error === 403 || response.data?.is_suspended) {
+function handleBadUserResponse(response: any, options: GetUserOptions = {}) {
+  if (
+    !options.allowSuspended &&
+    (response.error === 403 || response.data?.is_suspended)
+  ) {
     throw new BannedUserError();
   }
   if (response.error === 404) {
@@ -73,11 +80,14 @@ function handleBadUserResponse(response: any) {
   }
 }
 
-export async function getUser(url: string): Promise<User> {
+export async function getUser(
+  url: string,
+  options: GetUserOptions = {},
+): Promise<User> {
   const redditURL = new RedditURL(`${url}/about`);
   redditURL.jsonify();
   const response = await api(redditURL.toString());
-  handleBadUserResponse(response);
+  handleBadUserResponse(response, options);
   return formatUserData(response.data);
 }
 

--- a/components/HTML/RenderHTML.tsx
+++ b/components/HTML/RenderHTML.tsx
@@ -265,7 +265,7 @@ export function Element({ element, index, inheritedStyles }: ElementProps) {
     Wrapper = (props) => (
       <View onStartShouldSetResponder={() => true}>
         <View style={styles.imageContainer}>
-          <ImageViewer images={[element.attribs.src]} />
+          <ImageViewer images={[element.attribs.src]} aspectRatio={16 / 9} />
         </View>
         <View>{props.children}</View>
       </View>

--- a/components/Modals/Login.tsx
+++ b/components/Modals/Login.tsx
@@ -96,8 +96,8 @@ export default function Login() {
     if (loginFinished.current) return;
     loginFinished.current = true;
     setModal(null);
-    const logginSuccess = await logIn();
-    if (!logginSuccess) {
+    const loginSuccess = await logIn();
+    if (!loginSuccess) {
       handleLoginFailed();
     } else {
       resolver.current?.(false);

--- a/components/RedditDataRepresentations/Post/PostParts/CompactPostMedia.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/CompactPostMedia.tsx
@@ -87,6 +87,7 @@ export default function CompactPostMedia({ post }: CompactPostMediaProps) {
               thumbnail={post.imageThumbnail}
               straightToFullscreen
               exitedFullScreenCallback={() => setMediaOpen(false)}
+              aspectRatio={post.mediaAspectRatio}
             />
           )}
         </TouchableOpacity>

--- a/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/ImageView/ImageViewing.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/ImageView/ImageViewing.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext } from "react";
-import { View, ModalProps, Modal } from "react-native";
+import { ModalProps, Modal } from "react-native";
 
 import StatusBarManager from "./components/StatusBarManager";
 import useRequestClose from "./hooks/useRequestClose";
@@ -28,38 +28,29 @@ export default function ImageViewing(props: ImageViewingProps) {
   }
 
   return (
-    <View
-      onMoveShouldSetResponder={() => true}
-      onStartShouldSetResponder={() => true}
-      onResponderTerminationRequest={() => {
-        /* Prevents views underneath the modal from taking over */
-        return false;
-      }}
+    <Modal
+      transparent={presentationStyle === "overFullScreen"}
+      visible={visible}
+      presentationStyle={presentationStyle}
+      animationType={animationType}
+      onRequestClose={onRequestCloseEnhanced}
+      supportedOrientations={["portrait"]}
+      hardwareAccelerated
     >
-      <Modal
-        transparent={presentationStyle === "overFullScreen"}
-        visible={visible}
-        presentationStyle={presentationStyle}
-        animationType={animationType}
-        onRequestClose={onRequestCloseEnhanced}
-        supportedOrientations={["portrait"]}
-        hardwareAccelerated
-      >
-        <StatusBarManager presentationStyle={presentationStyle} />
-        <ImageSlider
-          images={props.images}
-          keyExtractor={props.keyExtractor}
-          initialImageIndex={props.initialImageIndex}
-          onRequestClose={onRequestClose}
-          onLongPress={props.onLongPress}
-          onImageIndexChange={props.onImageIndexChange}
-          swipeToCloseEnabled={props.swipeToCloseEnabled}
-          doubleTapToZoomEnabled={props.doubleTapToZoomEnabled}
-          delayLongPress={props.delayLongPress}
-          HeaderComponent={props.HeaderComponent}
-          FooterComponent={props.FooterComponent}
-        />
-      </Modal>
-    </View>
+      <StatusBarManager presentationStyle={presentationStyle} />
+      <ImageSlider
+        images={props.images}
+        keyExtractor={props.keyExtractor}
+        initialImageIndex={props.initialImageIndex}
+        onRequestClose={onRequestClose}
+        onLongPress={props.onLongPress}
+        onImageIndexChange={props.onImageIndexChange}
+        swipeToCloseEnabled={props.swipeToCloseEnabled}
+        doubleTapToZoomEnabled={props.doubleTapToZoomEnabled}
+        delayLongPress={props.delayLongPress}
+        HeaderComponent={props.HeaderComponent}
+        FooterComponent={props.FooterComponent}
+      />
+    </Modal>
   );
 }

--- a/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/ImageViewer.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/ImageViewer.tsx
@@ -1,4 +1,4 @@
-import { Image, useImage } from "expo-image";
+import { Image } from "expo-image";
 import React, { useState, useContext, useRef } from "react";
 import {
   Text,
@@ -16,12 +16,12 @@ import useMediaSharing from "../../../../../utils/useMediaSharing";
 
 export default function ImageViewer({
   images,
-  thumbnail,
   aspectRatio,
+  thumbnail,
 }: {
   images: string[];
+  aspectRatio: number;
   thumbnail?: string;
-  aspectRatio?: number;
 }) {
   const { currentDataMode } = useContext(DataModeContext);
   const shareMedia = useMediaSharing();
@@ -35,29 +35,9 @@ export default function ImageViewer({
 
   const isGif = new URL(images[0]).getRelativePath().endsWith(".gif");
 
-  let displayImgs = images.slice(0, 2);
-  if ((loadLowData || isGif) && thumbnail) {
-    displayImgs = [thumbnail];
-  }
+  const numImgsToDisplay = (loadLowData || isGif) && thumbnail ? 1 : 2;
 
-  const img1 = useImage({
-    uri: displayImgs[0],
-  });
-
-  const img2 = useImage(
-    {
-      uri: displayImgs[1],
-    },
-    {
-      onError: () => {
-        /* This image might not exist */
-      },
-    },
-  );
-
-  const imgRefs = [img1, ...(displayImgs.length === 2 ? [img2] : [])];
-
-  const imgRatio = aspectRatio ?? (img1 ? img1.width / img1.height : 0);
+  const imgRatio = aspectRatio;
   const heightIfFullSize = width / imgRatio;
   const imgHeight = Math.min(height * 0.6, heightIfFullSize);
 
@@ -66,7 +46,7 @@ export default function ImageViewer({
       style={[
         styles.imageViewerContainer,
         {
-          height: imgRefs.length >= 2 ? imgHeight / 2 : imgHeight,
+          height: numImgsToDisplay === 2 ? imgHeight / 2 : imgHeight,
         },
       ]}
     >
@@ -87,14 +67,14 @@ export default function ImageViewer({
           delayLongPress={500}
         />
       )}
-      {imgRefs.map((img, index, imgs) => (
+      {images.slice(0, numImgsToDisplay).map((img, index) => (
         /**
          * Don't change this to TouchableWithoutFeedback, it will break images in comments
          * by making them offset weirdly. I have no idea why.
          */
         <TouchableHighlight
-          activeOpacity={1}
           key={index}
+          activeOpacity={1}
           onPress={() => {
             setLoadLowData(false);
             initialImageIndex.current = index;
@@ -102,16 +82,16 @@ export default function ImageViewer({
           }}
           style={styles.touchableZone}
           underlayColor={theme.background}
-          onLongPress={() => shareMedia("image", images[index])}
+          onLongPress={() => shareMedia("image", img)}
         >
           <Image
             style={[
               styles.img,
               {
-                height: imgs.length >= 2 ? imgHeight / 2 : imgHeight,
+                height: numImgsToDisplay === 2 ? imgHeight / 2 : imgHeight,
               },
             ]}
-            recyclingKey={displayImgs[index]}
+            recyclingKey={img}
             contentFit="contain"
             source={img}
             transition={250}

--- a/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/ImageViewer.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/ImageViewer.tsx
@@ -4,13 +4,12 @@ import {
   Text,
   StyleSheet,
   View,
-  Pressable,
+  TouchableHighlight,
   useWindowDimensions,
 } from "react-native";
 
 import { default as ImageView } from "./ImageView/ImageViewing";
 import { DataModeContext } from "../../../../../contexts/SettingsContexts/DataModeContext";
-import { ModalContext } from "../../../../../contexts/ModalContext";
 import { ThemeContext } from "../../../../../contexts/SettingsContexts/ThemeContext";
 import URL from "../../../../../utils/URL";
 import useMediaSharing from "../../../../../utils/useMediaSharing";
@@ -27,68 +26,20 @@ export default function ImageViewer({
   const { currentDataMode } = useContext(DataModeContext);
   const shareMedia = useMediaSharing();
   const { width, height } = useWindowDimensions();
-  const { setModal } = useContext(ModalContext);
 
   const [loadLowData, setLoadLowData] = useState(currentDataMode === "lowData");
+  const [visible, setVisible] = useState(false);
   const initialImageIndex = useRef(0);
 
   const { theme } = useContext(ThemeContext);
 
   const isGif = new URL(images[0]).getRelativePath().endsWith(".gif");
-  const maxPreviewWidth = Math.ceil(width);
-  const maxPreviewHeight = Math.ceil(height * 0.6);
 
-  let displayImgs = images.slice(0, 2);
-  if ((loadLowData || isGif) && thumbnail) {
-    displayImgs = [thumbnail];
-  }
-  const secondaryDisplayImg = displayImgs[1] ?? displayImgs[0];
+  const numImgsToDisplay = (loadLowData || isGif) && thumbnail ? 1 : 2;
 
-  const img1 = useImage(displayImgs[0], {
-    maxWidth: maxPreviewWidth,
-    maxHeight: maxPreviewHeight,
-  });
-
-  const img2 = useImage(
-    secondaryDisplayImg,
-    {
-      maxWidth: maxPreviewWidth,
-      maxHeight: maxPreviewHeight,
-      onError: () => {
-        /* This image might not exist */
-      },
-    },
-  );
-
-  const imgRefs = [img1, ...(displayImgs.length === 2 ? [img2] : [])];
-
-  const imgRatio = aspectRatio ?? (img1 ? img1.width / img1.height : 0);
+  const imgRatio = aspectRatio;
   const heightIfFullSize = width / imgRatio;
   const imgHeight = Math.min(height * 0.6, heightIfFullSize);
-
-  const openImageViewer = (index: number) => {
-    setLoadLowData(false);
-    initialImageIndex.current = index;
-    setModal(
-      <ImageView
-        images={images.map((image) => ({ uri: image }))}
-        initialImageIndex={index}
-        presentationStyle="overFullScreen"
-        animationType="none"
-        visible={true}
-        onRequestClose={() => setModal(undefined)}
-        onLongPress={(imgSource) =>
-          typeof imgSource === "object" &&
-          imgSource.uri &&
-          shareMedia("image", imgSource.uri)
-        }
-        onImageIndexChange={(imageIndex) => {
-          initialImageIndex.current = imageIndex;
-        }}
-        delayLongPress={500}
-      />,
-    );
-  };
 
   return (
     <View
@@ -99,22 +50,39 @@ export default function ImageViewer({
         },
       ]}
     >
-      {imgRefs.map((img, index, imgs) => (
+      {!loadLowData && (
+        <ImageView
+          images={images.map((image) => ({ uri: image }))}
+          initialImageIndex={initialImageIndex.current}
+          presentationStyle="overFullScreen"
+          animationType="none"
+          visible={visible}
+          onRequestClose={() => setVisible(false)}
+          onLongPress={(imgSource) =>
+            typeof imgSource === "object" &&
+            imgSource.uri &&
+            shareMedia("image", imgSource.uri)
+          }
+          onImageIndexChange={(index) => (initialImageIndex.current = index)}
+          delayLongPress={500}
+        />
+      )}
+      {images.slice(0, numImgsToDisplay).map((img, index) => (
         /**
          * Don't change this to TouchableWithoutFeedback, it will break images in comments
          * by making them offset weirdly. I have no idea why.
          */
-        <Pressable
+        <TouchableHighlight
           key={index}
-          onPress={(event) => {
-            event.stopPropagation();
-            openImageViewer(index);
+          activeOpacity={1}
+          onPress={() => {
+            setLoadLowData(false);
+            initialImageIndex.current = index;
+            setVisible(true);
           }}
           style={styles.touchableZone}
-          onLongPress={(event) => {
-            event.stopPropagation();
-            shareMedia("image", images[index]);
-          }}
+          underlayColor={theme.background}
+          onLongPress={() => shareMedia("image", img)}
         >
           <Image
             style={[
@@ -128,7 +96,7 @@ export default function ImageViewer({
             source={img}
             transition={250}
           />
-        </Pressable>
+        </TouchableHighlight>
       ))}
       {images.length >= 2 && (
         <View

--- a/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/Link.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/Link.tsx
@@ -1,4 +1,4 @@
-import { Image, useImage } from "expo-image";
+import { Image } from "expo-image";
 import { openExternalLink } from "../../../../../utils/openExternalLink";
 import React, { useContext } from "react";
 import { Text, StyleSheet, TouchableOpacity } from "react-native";
@@ -21,17 +21,6 @@ export default function Link({ post }: { post: Post | PostDetail }) {
   const { interactedWithPost } = useContext(PostInteractionContext);
 
   const url = post.externalLink ?? post.crossCommentLink;
-
-  const imgRef = useImage(
-    {
-      uri: post.openGraphData?.image,
-    },
-    {
-      onError: () => {
-        /* This image might not exist */
-      },
-    },
-  );
 
   return (
     <TouchableOpacity
@@ -59,7 +48,7 @@ export default function Link({ post }: { post: Post | PostDetail }) {
         <>
           {currentDataMode === "normal" && (
             <Image
-              source={imgRef}
+              source={post.openGraphData.image}
               contentFit="cover"
               style={{ height: 200, borderRadius: 10 }}
               transition={250}

--- a/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/Link.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/Link.tsx
@@ -42,9 +42,7 @@ export default function Link({ post }: { post: Post | PostDetail }) {
         }
       }}
     >
-      {post.openGraphData?.image &&
-      post.openGraphData?.title &&
-      post.openGraphData?.description ? (
+      {post.openGraphData?.image && post.openGraphData?.title ? (
         <>
           {currentDataMode === "normal" && (
             <Image
@@ -66,7 +64,7 @@ export default function Link({ post }: { post: Post | PostDetail }) {
           >
             {post.openGraphData.title}
           </Text>
-          {linkDescriptionLength !== 0 && (
+          {post.openGraphData.description && linkDescriptionLength !== 0 && (
             <Text
               style={[
                 styles.descriptionText,

--- a/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/VideoPlayer.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/VideoPlayer.tsx
@@ -110,9 +110,13 @@ function VideoPlayer({
     outputRange: ["0%", "100%"],
   });
 
+  const viewerOpenGuard = useRef(false);
+
   const openFullscreenVideo = () => {
+    if (viewerOpenGuard.current) return;
     interactedWithPost();
     if (Platform.OS === "android") {
+      viewerOpenGuard.current = true;
       player.pause();
       player.volume = 0;
       mediaViewerRef.current?.open(0);
@@ -129,6 +133,8 @@ function VideoPlayer({
     } else {
       player.pause();
     }
+    // Delay re-enabling to prevent touch events from immediately reopening
+    setTimeout(() => { viewerOpenGuard.current = false; }, 300);
   };
 
   React.useEffect(() => {

--- a/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/VideoPlayer.tsx
+++ b/components/RedditDataRepresentations/Post/PostParts/PostMediaParts/VideoPlayer.tsx
@@ -27,7 +27,7 @@ type VideoPlayerProps = {
   videoDownloadURL?: string;
   straightToFullscreen?: boolean;
   exitedFullScreenCallback?: () => void;
-  aspectRatio?: number;
+  aspectRatio: number;
 };
 
 function VideoPlayer({
@@ -127,7 +127,7 @@ function VideoPlayer({
         >
           {/* Have to put an invisible layer on top of the ImageViewer to keep it from stealing clicks */}
           <View style={styles.invisibleLayer} />
-          <ImageViewer images={[thumbnail]} />
+          <ImageViewer images={[thumbnail]} aspectRatio={aspectRatio} />
           <View
             style={[
               styles.isVideoContainer,

--- a/contexts/AccountContext.tsx
+++ b/contexts/AccountContext.tsx
@@ -40,7 +40,7 @@ export function AccountProvider({ children }: React.PropsWithChildren) {
       if (username) {
         await RedditCookies.restoreSessionCookies(username);
       }
-      const user = await getUser("/user/me");
+      const user = await getUser("/user/me", { allowSuspended: true });
       if (username && user.userName !== username) {
         throw new Error("Authenticated session out of sync");
       }

--- a/pages/UserPage.tsx
+++ b/pages/UserPage.tsx
@@ -62,7 +62,9 @@ export default function UserPage({ route }: StackPageProps<"UserPage">) {
       .slice(0, 3)
       .join("/");
     try {
-      const userData = await getUser(`https://www.reddit.com${userUrl}`);
+      const userData = await getUser(`https://www.reddit.com${userUrl}`, {
+        allowSuspended: true,
+      });
       setUser(userData);
     } catch (e) {
       if (e instanceof BannedUserError || e instanceof UserDoesNotExistError) {


### PR DESCRIPTION
## Summary

Two fixes for media viewing from the feed on Android.

### Fix 1: Image viewer freeze
Opening an image from the feed caused the app to freeze. The responder-claiming wrapper `View` around the `Modal` in `ImageViewing.tsx` competed with `Slideable`'s gesture handling, creating a deadlock where neither would yield. The fix removes the wrapper. The `Modal` component's native window provides touch isolation on both platforms, making the wrapper unnecessary.

### Fix 2: Video viewer back-button loop
Opening a video from the feed worked, but pressing Back to close it caused the viewer to immediately reopen in an infinite loop. Touch events leaked through the transparent modal to the `TouchableWithoutFeedback` underneath, retriggering `openFullscreenVideo`. The fix adds a guard ref that blocks spurious re-opens for 300ms after closing.

## What changed

- `ImageViewing.tsx`: Removed the `View` wrapper with responder claims around the `Modal`
- `VideoPlayer.tsx`: Added `viewerOpenGuard` ref to prevent the back-button reopen loop

## Additional context

This branch also includes the 4 master commits that the android branch was behind on:
- `9b6d794` fixed shadowbanned users missing items on their own profile page
- `5cbd4b4` fixed shadowbanned users being unable to log in
- `40ef0c6` fix some links (like wikipedia) not showing an image
- `b34d0d2` fixed image posts momentarily showing the wrong image for real this time

Conflicts in `ImageViewer.tsx` and `VideoPlayer.tsx` were resolved keeping the android branch versions.

## Test plan

- [x] Tapping images in the feed opens the viewer without freezing
- [x] X button closes the image viewer
- [x] Double-tap to zoom works
- [x] Long-press triggers share
- [x] Opening a video from the feed plays correctly
- [x] Back button closes the video viewer without looping
- [x] Reopening a video after closing works normally
- [x] Opening images/videos from within a thread still works
- [x] Tested on Samsung S26 Ultra