### PR TITLE
Fix Android media sharing payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "expo-notifications": "~0.32.12",
         "expo-router": "~6.0.14",
         "expo-secure-store": "~15.0.7",
+        "expo-sharing": "~14.0.7",
         "expo-splash-screen": "~31.0.10",
         "expo-sqlite": "~16.0.9",
         "expo-status-bar": "~3.0.8",
@@ -8078,6 +8079,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-14.0.8.tgz",
+      "integrity": "sha512-A1pPr2iBrxypFDCWVAESk532HK+db7MFXbvO2sCV9ienaFXAk7lIBm6bkqgE6vzRd9O3RGdEGzYx80cYlc089Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "expo-notifications": "~0.32.12",
     "expo-router": "~6.0.14",
     "expo-secure-store": "~15.0.7",
+    "expo-sharing": "~14.0.7",
     "expo-splash-screen": "~31.0.10",
     "expo-sqlite": "~16.0.9",
     "expo-status-bar": "~3.0.8",

--- a/utils/useMediaSharing.tsx
+++ b/utils/useMediaSharing.tsx
@@ -1,9 +1,9 @@
-import { File, Paths } from "expo-file-system/next";
+import { Directory, File, Paths } from "expo-file-system/next";
+import * as Sharing from "expo-sharing";
 import { useContext, useRef } from "react";
 import {
   ActivityIndicator,
   Alert,
-  Share,
   View,
   StyleSheet,
   Text,
@@ -14,6 +14,88 @@ import {
 import URL from "./URL";
 import { ModalContext } from "../contexts/ModalContext";
 import { ThemeContext } from "../contexts/SettingsContexts/ThemeContext";
+
+const SHARE_CACHE_DIRECTORY = "hydra-shares";
+const SHARE_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+const FILE_TYPES = {
+  gif: { extension: "gif", mimeType: "image/gif", uti: "com.compuserve.gif" },
+  jpeg: { extension: "jpg", mimeType: "image/jpeg", uti: "public.jpeg" },
+  jpg: { extension: "jpg", mimeType: "image/jpeg", uti: "public.jpeg" },
+  m4v: {
+    extension: "m4v",
+    mimeType: "video/x-m4v",
+    uti: "com.apple.m4v-video",
+  },
+  mp4: { extension: "mp4", mimeType: "video/mp4", uti: "public.mpeg-4" },
+  png: { extension: "png", mimeType: "image/png", uti: "public.png" },
+  webp: {
+    extension: "webp",
+    mimeType: "image/webp",
+    uti: "org.webmproject.webp",
+  },
+} as const;
+
+const DEFAULT_FILE_TYPE = {
+  image: { extension: "jpg", mimeType: "image/jpeg", uti: "public.jpeg" },
+  video: { extension: "mp4", mimeType: "video/mp4", uti: "public.mpeg-4" },
+} as const;
+
+function getShareDirectory() {
+  const directory = new Directory(Paths.cache, SHARE_CACHE_DIRECTORY);
+  if (!directory.exists) {
+    directory.create({ intermediates: true, idempotent: true });
+  }
+  return directory;
+}
+
+function cleanupStaleShares(directory: Directory) {
+  const now = Date.now();
+
+  for (const item of directory.list()) {
+    if (item instanceof Directory) continue;
+
+    try {
+      const { modificationTime, creationTime } = item.info();
+      const timestamp = modificationTime ?? creationTime ?? 0;
+      if (!timestamp || now - timestamp > SHARE_CACHE_MAX_AGE_MS) {
+        item.delete();
+      }
+    } catch (_) {
+      // Cache cleanup is best effort; sharing should not fail because a stale
+      // file could not be inspected or deleted.
+    }
+  }
+}
+
+function getFileExtension(fileName: string) {
+  return fileName.split(".").pop()?.toLowerCase() ?? "";
+}
+
+function getFileType(type: "image" | "video", fileName: string) {
+  const extension = getFileExtension(fileName);
+  return (
+    FILE_TYPES[extension as keyof typeof FILE_TYPES] ?? DEFAULT_FILE_TYPE[type]
+  );
+}
+
+function getShareFileName(type: "image" | "video", mediaUrl: string) {
+  const rawFileName = new URL(mediaUrl).getBasePath().split("/").pop() ?? "";
+  const decodedFileName = decodeURIComponent(rawFileName);
+  const sanitizedFileName = decodedFileName
+    .replace(/[^a-zA-Z0-9._-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+  const fallback = `media.${DEFAULT_FILE_TYPE[type].extension}`;
+  const baseFileName = sanitizedFileName || fallback;
+  const fileType = getFileType(type, baseFileName);
+  const extension = getFileExtension(baseFileName);
+  const fileName = extension
+    ? baseFileName
+    : `${baseFileName}.${fileType.extension}`;
+
+  return `${Date.now()}-${fileName}`;
+}
 
 export default function useMediaSharing() {
   const { setModal } = useContext(ModalContext);
@@ -56,19 +138,22 @@ export default function useMediaSharing() {
           </View>
         </TouchableOpacity>,
       );
-      const fileName = new URL(mediaUrl).getBasePath().split("/").pop();
-      const file = new File(`${Paths.cache.uri}/${fileName}`);
-      if (file.exists) {
-        file.delete();
-      }
-      await File.downloadFileAsync(mediaUrl, file);
+      const directory = getShareDirectory();
+      cleanupStaleShares(directory);
+
+      const fileName = getShareFileName(type, mediaUrl);
+      const file = new File(directory, fileName);
+      const fileType = getFileType(type, fileName);
+
+      await File.downloadFileAsync(mediaUrl, file, { idempotent: true });
       setModal(null);
-      await Share.share({
-        url: file.uri,
+      await Sharing.shareAsync(file.uri, {
+        dialogTitle: `Share ${type === "image" ? "Image" : "Video"}`,
+        mimeType: fileType.mimeType,
+        UTI: fileType.uti,
       });
-      file.delete();
     } catch (_e) {
-      Alert.alert("Error", `Failed to download ${type}`);
+      Alert.alert("Error", `Failed to share ${type}`);
       setModal(null);
     }
     alreadyAsking.current = false;


### PR DESCRIPTION
## Summary
- route media sharing through `expo-sharing` so Android receives downloaded local files instead of URL text
- keep shared media files available after the share sheet opens and clean old cache files opportunistically
- add MIME/UTI metadata for common image and video formats

## Validation
- `npm run tsc`
- `npx eslint utils/useMediaSharing.tsx`
- `./gradlew assembleDebug --console=plain --no-daemon --no-parallel --max-workers=1 -Dorg.gradle.workers.max=1 -PreactNativeArchitectures=arm64-v8a`

Note: this adds a native Expo module, so Android/iOS clients need a new build for the change.